### PR TITLE
Externalize credentials and secure tests

### DIFF
--- a/src/main/java/com/example/explorecalijpa/config/SecurityConfig.java
+++ b/src/main/java/com/example/explorecalijpa/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.explorecalijpa.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -16,6 +17,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @EnableMethodSecurity // Optional: enables @PreAuthorize, @RolesAllowed, etc.
 public class SecurityConfig {
+
+  @Value("${app.security.admin.password}")
+  private String adminPassword;
+
+  @Value("${app.security.user.password}")
+  private String userPassword;
 
   /**
    * Defines the security filter chain for HTTP requests.
@@ -38,12 +45,12 @@ public class SecurityConfig {
   @Bean
   public UserDetailsService userDetailsService() {
     UserDetails admin = User.withUsername("admin")
-        .password("{noop}password")
+        .password("{noop}" + adminPassword)
         .roles("ADMIN")
         .build();
 
     UserDetails student = User.withUsername("student")
-        .password("{noop}password")
+        .password("{noop}" + userPassword)
         .roles("USER")
         .build();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,7 @@ spring.application.name=explorecali-jpa
 
 #Now use Flyway to create the schema in mysql
 spring.jpa.hibernate.ddl-auto=none
+
+# security
+app.security.admin.password=${ADMIN_PASSWORD:password}
+app.security.user.password=${USER_PASSWORD:password}

--- a/src/test/java/com/example/explorecalijpa/web/TourRatingControllerTest.java
+++ b/src/test/java/com/example/explorecalijpa/web/TourRatingControllerTest.java
@@ -12,9 +12,11 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -40,6 +42,9 @@ public class TourRatingControllerTest {
   @Autowired
   private TestRestTemplate restTemplate;
 
+  @Value("${app.security.admin.password}")
+  private String adminPassword;
+
   @MockBean
   private TourRatingService serviceMock;
 
@@ -50,6 +55,11 @@ public class TourRatingControllerTest {
   private Tour tourMock;
 
   private RatingDto ratingDto = new RatingDto(SCORE, COMMENT,CUSTOMER_ID);
+
+  @BeforeEach
+  void setUp() {
+    restTemplate = restTemplate.withBasicAuth("admin", adminPassword);
+  }
 
   @Test
   void testCreateTourRating() {


### PR DESCRIPTION
## Summary
- externalize in-memory user passwords via application properties
- configure controller tests to authenticate with injected admin password

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2a7832c83298af3cf4933901fae