### PR TITLE
Add tour recommendation service and controller

### DIFF
--- a/src/main/java/com/example/explorecalijpa/ExplorecaliJpaApplication.java
+++ b/src/main/java/com/example/explorecalijpa/ExplorecaliJpaApplication.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.context.annotation.Bean;
 
 import com.example.explorecalijpa.business.TourPackageService;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 
 @SpringBootApplication
+@EnableScheduling
 public class ExplorecaliJpaApplication implements CommandLineRunner {
  
     @Bean

--- a/src/main/java/com/example/explorecalijpa/business/RecommendationService.java
+++ b/src/main/java/com/example/explorecalijpa/business/RecommendationService.java
@@ -1,0 +1,85 @@
+package com.example.explorecalijpa.business;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.example.explorecalijpa.model.Tour;
+import com.example.explorecalijpa.model.TourRating;
+import com.example.explorecalijpa.model.TourRecommendation;
+import com.example.explorecalijpa.repo.TourRatingRepository;
+
+/**
+ * Service providing tour recommendations based on ratings.
+ */
+@Service
+public class RecommendationService {
+
+  private final TourRatingRepository tourRatingRepository;
+  private final Map<Integer, List<TourRecommendation>> topNCache = new ConcurrentHashMap<>();
+
+  public RecommendationService(TourRatingRepository tourRatingRepository) {
+    this.tourRatingRepository = tourRatingRepository;
+  }
+
+  /**
+   * Recommend tours to a customer based on overall ratings excluding tours the
+   * customer has already rated.
+   *
+   * @param customerId customer identifier
+   * @return list of recommended tours sorted by average score
+   */
+  public List<TourRecommendation> recommendByCustomer(int customerId) {
+    List<TourRating> allRatings = tourRatingRepository.findAll();
+    Set<Integer> ratedByCustomer = tourRatingRepository.findByCustomerId(customerId).stream()
+        .map(tr -> tr.getTour().getId()).collect(Collectors.toSet());
+
+    Map<Tour, Double> averages = allRatings.stream()
+        .collect(Collectors.groupingBy(TourRating::getTour, Collectors.averagingInt(TourRating::getScore)));
+
+    return averages.entrySet().stream()
+        .filter(e -> !ratedByCustomer.contains(e.getKey().getId()))
+        .sorted(Map.Entry.<Tour, Double>comparingByValue().reversed())
+        .map(e -> new TourRecommendation(e.getKey(), e.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Recommend the top N tours across all customers.
+   *
+   * @param limit number of tours to return
+   * @return top rated tours
+   */
+  public List<TourRecommendation> recommendTopN(int limit) {
+    if (topNCache.containsKey(limit)) {
+      return topNCache.get(limit);
+    }
+
+    List<TourRating> ratings = tourRatingRepository.findAll();
+    Map<Tour, Double> averages = ratings.stream()
+        .collect(Collectors.groupingBy(TourRating::getTour, Collectors.averagingInt(TourRating::getScore)));
+
+    List<TourRecommendation> result = averages.entrySet().stream()
+        .sorted(Map.Entry.<Tour, Double>comparingByValue().reversed())
+        .limit(limit)
+        .map(e -> new TourRecommendation(e.getKey(), e.getValue()))
+        .collect(Collectors.toList());
+
+    topNCache.put(limit, result);
+    return result;
+  }
+
+  /**
+   * Clear cached recommendation results periodically.
+   */
+  @Scheduled(fixedDelay = 300000)
+  public void evictCache() {
+    topNCache.clear();
+  }
+}
+

--- a/src/main/java/com/example/explorecalijpa/model/TourRecommendation.java
+++ b/src/main/java/com/example/explorecalijpa/model/TourRecommendation.java
@@ -1,0 +1,29 @@
+package com.example.explorecalijpa.model;
+
+/**
+ * Simple value object representing a recommended tour and its average score.
+ */
+public class TourRecommendation {
+  private Integer tourId;
+  private String title;
+  private Double averageScore;
+
+  public TourRecommendation(Tour tour, Double averageScore) {
+    this.tourId = tour.getId();
+    this.title = tour.getTitle();
+    this.averageScore = averageScore;
+  }
+
+  public Integer getTourId() {
+    return tourId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public Double getAverageScore() {
+    return averageScore;
+  }
+}
+

--- a/src/main/java/com/example/explorecalijpa/repo/TourRatingRepository.java
+++ b/src/main/java/com/example/explorecalijpa/repo/TourRatingRepository.java
@@ -33,4 +33,12 @@ public interface TourRatingRepository extends JpaRepository<TourRating, Integer>
    * @return TourRating if found, null otherwise.
    */
   Optional<TourRating> findByTourIdAndCustomerId(Integer tourId, Integer customerId);
+
+  /**
+   * Lookup all TourRatings made by a customer.
+   *
+   * @param customerId the customer identifier
+   * @return a list of TourRatings for the customer
+   */
+  List<TourRating> findByCustomerId(Integer customerId);
 }

--- a/src/main/java/com/example/explorecalijpa/web/RecommendationController.java
+++ b/src/main/java/com/example/explorecalijpa/web/RecommendationController.java
@@ -1,0 +1,42 @@
+package com.example.explorecalijpa.web;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.explorecalijpa.business.RecommendationService;
+import com.example.explorecalijpa.model.TourRecommendation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing tour recommendation endpoints.
+ */
+@RestController
+@Tag(name = "Recommendations", description = "Tour recommendation API")
+@RequestMapping("/recommendations")
+public class RecommendationController {
+
+  private final RecommendationService recommendationService;
+
+  public RecommendationController(RecommendationService recommendationService) {
+    this.recommendationService = recommendationService;
+  }
+
+  @GetMapping("/customer/{customerId}")
+  @Operation(summary = "Recommend tours for a customer")
+  public List<TourRecommendation> recommendForCustomer(@PathVariable int customerId) {
+    return recommendationService.recommendByCustomer(customerId);
+  }
+
+  @GetMapping("/top/{limit}")
+  @Operation(summary = "Get top rated tours")
+  public List<TourRecommendation> recommendTop(@PathVariable int limit) {
+    return recommendationService.recommendTopN(limit);
+  }
+}
+

--- a/src/test/java/com/example/explorecalijpa/business/RecommendationServiceTest.java
+++ b/src/test/java/com/example/explorecalijpa/business/RecommendationServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.explorecalijpa.business;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.explorecalijpa.model.Tour;
+import com.example.explorecalijpa.model.TourRating;
+import com.example.explorecalijpa.model.TourRecommendation;
+import com.example.explorecalijpa.repo.TourRatingRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class RecommendationServiceTest {
+
+  @Mock
+  private TourRatingRepository tourRatingRepository;
+
+  private RecommendationService recommendationService;
+
+  private Tour tour1;
+  private Tour tour2;
+  private Tour tour3;
+  private List<TourRating> allRatings;
+
+  @BeforeEach
+  void setup() {
+    recommendationService = new RecommendationService(tourRatingRepository);
+
+    tour1 = mock(Tour.class);
+    when(tour1.getId()).thenReturn(1);
+    when(tour1.getTitle()).thenReturn("t1");
+
+    tour2 = mock(Tour.class);
+    when(tour2.getId()).thenReturn(2);
+    when(tour2.getTitle()).thenReturn("t2");
+
+    tour3 = mock(Tour.class);
+    when(tour3.getId()).thenReturn(3);
+    when(tour3.getTitle()).thenReturn("t3");
+
+    allRatings = List.of(
+        new TourRating(tour1, 1, 5),
+        new TourRating(tour1, 2, 4),
+        new TourRating(tour2, 3, 2),
+        new TourRating(tour3, 2, 5),
+        new TourRating(tour3, 3, 5));
+  }
+
+  @Test
+  void recommendTopN() {
+    when(tourRatingRepository.findAll()).thenReturn(allRatings);
+
+    List<TourRecommendation> recs = recommendationService.recommendTopN(2);
+
+    assertThat(recs.size(), is(2));
+    assertThat(recs.get(0).getTourId(), is(3));
+    assertThat(recs.get(1).getTourId(), is(1));
+  }
+
+  @Test
+  void recommendByCustomer() {
+    when(tourRatingRepository.findAll()).thenReturn(allRatings);
+    when(tourRatingRepository.findByCustomerId(1)).thenReturn(List.of(new TourRating(tour1, 1, 5)));
+
+    List<TourRecommendation> recs = recommendationService.recommendByCustomer(1);
+
+    assertThat(recs.size(), is(2));
+    assertThat(recs.get(0).getTourId(), is(3));
+    assertThat(recs.get(1).getTourId(), is(2));
+  }
+}
+

--- a/src/test/java/com/example/explorecalijpa/web/RecommendationControllerTest.java
+++ b/src/test/java/com/example/explorecalijpa/web/RecommendationControllerTest.java
@@ -1,0 +1,47 @@
+package com.example.explorecalijpa.web;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.example.explorecalijpa.business.RecommendationService;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class RecommendationControllerTest {
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @MockBean
+  private RecommendationService recommendationService;
+
+  @Test
+  void testTopRecommendations() {
+    when(recommendationService.recommendTopN(anyInt())).thenReturn(List.of());
+    ResponseEntity<String> res = restTemplate.getForEntity("/recommendations/top/2", String.class);
+    assertThat(res.getStatusCode(), is(HttpStatus.OK));
+    verify(recommendationService).recommendTopN(2);
+  }
+
+  @Test
+  void testRecommendationsByCustomer() {
+    when(recommendationService.recommendByCustomer(anyInt())).thenReturn(List.of());
+    ResponseEntity<String> res = restTemplate.getForEntity("/recommendations/customer/1", String.class);
+    assertThat(res.getStatusCode(), is(HttpStatus.OK));
+    verify(recommendationService).recommendByCustomer(1);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `findByCustomerId` to `TourRatingRepository`
- implement `RecommendationService` with caching and scheduled cache eviction
- expose recommendation endpoints for top tours and customer-based suggestions
- add unit and controller tests for recommendation logic

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b655b3120883298ca9c7403dcd7f34